### PR TITLE
Mosinonly and sovaprif tags

### DIFF
--- a/code/game/objects/map_metadata/_map_metadata.dm
+++ b/code/game/objects/map_metadata/_map_metadata.dm
@@ -41,6 +41,7 @@ var/civmax_research = list(230,230,230)
 		"Nassau Shores:1" = "sound/music/nassau_shores.ogg",)
 	var/mission_start_message = "Round will start soon!"
 	var/is_RP = FALSE
+	var/mosinonly = FALSE
 	var/squads = 1
 	var/list/faction1_squads = list(
 		1 = list(),

--- a/code/game/objects/map_metadata/khalkhyn_gol.dm
+++ b/code/game/objects/map_metadata/khalkhyn_gol.dm
@@ -19,6 +19,7 @@
 	faction_distribution_coeffs = list(JAPANESE = 0.6, RUSSIAN = 0.4)
 	battle_name = "battle of Khalkhyn Gol"
 	mission_start_message = "<font size=4>All factions have <b>8 minutes</b> to prepare before the ceasefire ends!<br>The Japanese will win if they capture the <b>Soviet command</b>. The Soviets will win if they manage to capture the <b>Japanese command</b>.</font>"
+	mosinonly = TRUE
 	faction1 = JAPANESE
 	faction2 = RUSSIAN
 	grace_wall_timer = 4800
@@ -32,10 +33,8 @@
 		. = TRUE
 	else if (J.is_navy == TRUE || J.is_yakuza || J.is_tanker == TRUE || J.is_prison == TRUE || J.is_ss_panzer == TRUE || J.is_pacific == TRUE)
 		. = FALSE
-	else if (J.is_ww2 == TRUE)
+	else if (J.is_ww2 == TRUE && !J.is_sovaprif == TRUE)
 		. = TRUE
-	else if (istype(J, /datum/job/russian/antitank_soldier_soviet) || istype(J, /datum/job/russian/antitank_assistant_soldier_soviet))
-		. = FALSE
 	else
 		. = FALSE
 

--- a/code/modules/1713/jobs/_special.dm
+++ b/code/modules/1713/jobs/_special.dm
@@ -88,6 +88,8 @@
 /datum/job/var/is_ukrainerussowar = FALSE
 /datum/job/var/is_russojapwar = FALSE
 /datum/job/var/is_smallsiegemoscow = FALSE
+/datum/job/var/mosinonly = FALSE
+/datum/job/var/is_sovaprif = FALSE
 /datum/job/var/is_lab = FALSE
 /datum/job/var/is_afghan = FALSE
 /datum/job/var/is_soviet = FALSE

--- a/code/modules/1713/jobs/russian.dm
+++ b/code/modules/1713/jobs/russian.dm
@@ -609,6 +609,7 @@
 	spawn_location = "JoinLateRU"
 	can_be_female = TRUE
 	is_ww2 = TRUE
+	is_sovaprif = TRUE
 	uses_squads = TRUE
 	is_karelia = FALSE
 
@@ -672,6 +673,7 @@
 	is_ww2 = TRUE
 	uses_squads = TRUE
 	is_karelia = FALSE
+	is_sovaprif = TRUE
 
 	min_positions = 2
 	max_positions = 4
@@ -694,21 +696,27 @@
 //weapons
 	if (map.ID == MAP_STALINGRAD || map.ID == MAP_SMALLSIEGEMOSCOW || map.ID == MAP_KARELIA)
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/coat/ww2/sovcoat(H), slot_wear_suit)
+
 	var/obj/item/clothing/under/uniform = H.w_uniform
-	var/randimpw = rand(1,3)
-	switch(randimpw)
-		if (1)
-			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
-			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/snipermosin/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/snipermosin(null)
-			uniform.attackby(webbing, H)
-		if (2)
-			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppsh(H), slot_shoulder)
-			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppshassault/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppshassault(null)
-			uniform.attackby(webbing, H)
-		if (3)
-			H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/svt(H), slot_shoulder)
-			var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svtassault/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svtassault(null)
-			uniform.attackby(webbing, H)
+	if (mosinonly == TRUE)
+		H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
+		var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/snipermosin/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/snipermosin(null)
+		uniform.attackby(webbing, H)
+	else
+		var/randimpw = rand(1,3)
+		switch(randimpw)
+			if (1)
+				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/boltaction/mosin/m30(H), slot_shoulder)
+				var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/snipermosin/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/snipermosin(null)
+				uniform.attackby(webbing, H)
+			if (2)
+				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/submachinegun/ppsh(H), slot_shoulder)
+				var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppshassault/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/ppshassault(null)
+				uniform.attackby(webbing, H)
+			if (3)
+				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/semiautomatic/svt(H), slot_shoulder)
+				var/obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svtassault/webbing = new /obj/item/clothing/accessory/storage/webbing/ww1/leather/ww2/svtassault(null)
+				uniform.attackby(webbing, H)
 
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/ptrd_box(H), slot_l_store)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/ptrd_box/ap(H), slot_r_store)


### PR DESCRIPTION
- mosinonly : any map with mosinonly = TRUE in their metadata variables will only get mosin riflemen (leaving out svt and ppsh)
- sovaprif : denotes the soviet AP rifleman jobs allowing them to be sorted from/for job_enabled_specialcheck.
- Both tags implemented on Khalkyn Gol.